### PR TITLE
Improve portability

### DIFF
--- a/bin/whichramda.js
+++ b/bin/whichramda.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 var fs = require("fs");
 var whichRamda = require("../dist").default;


### PR DESCRIPTION
`node` is not guaranteed to be in `/usr/local/bin/node`, so use `env` to find it.